### PR TITLE
Add StateVector class

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -41,6 +41,7 @@ OBJS = \
 	Scalar.o \
 	ScalarToTecplot.o \
 	State.o \
+    StateVector.o \
 	utils.o \
 	VectorOperations.o
 

--- a/config/make.inc.gcc
+++ b/config/make.inc.gcc
@@ -3,7 +3,7 @@
 CXX = g++
 
 # flags for compiling with optimization
-CXXFLAGS = -Wall -g -fast -funroll-loops -DNDEBUG
+CXXFLAGS = -Wall -g -O4 -funroll-loops -DNDEBUG
 
 # for debugging, uncomment the following line
 # CXXFLAGS = -Wall -g

--- a/config/make.inc.gcc
+++ b/config/make.inc.gcc
@@ -3,7 +3,7 @@
 CXX = g++
 
 # flags for compiling with optimization
-CXXFLAGS = -Wall -g -O4 -funroll-loops -DNDEBUG
+CXXFLAGS = -Wall -g -Ofast -funroll-loops -DNDEBUG
 
 # for debugging, uncomment the following line
 # CXXFLAGS = -Wall -g

--- a/src/BoundaryVector.h
+++ b/src/BoundaryVector.h
@@ -142,10 +142,22 @@ public:
         return *this;
     }
 
+    /// f += a
+    inline BoundaryVector& operator+=(double a) {
+        _data += a;
+        return *this;
+    }
+
     /// f -= g
     inline BoundaryVector& operator-=(const BoundaryVector& f) {
         assert(f._numPoints == _numPoints);
         _data -= f._data;
+        return *this;
+    }
+
+    /// f -= a
+    inline BoundaryVector& operator-=(double a) {
+        _data -= a;
         return *this;
     }
 
@@ -167,11 +179,25 @@ public:
         h += g;
         return h;
     }
+
+    /// f + a
+    inline BoundaryVector operator+(double a) {
+        BoundaryVector h = *this;
+        h += a;
+        return h;
+    }
     
     /// f - g
     inline BoundaryVector operator-(const BoundaryVector& g) {
         BoundaryVector h = *this;
         h -= g;
+        return h;
+    }
+
+    /// f - a
+    inline BoundaryVector operator-(double a) {
+        BoundaryVector h = *this;
+        h -= a;
         return h;
     }
     

--- a/src/ScalarToTecplot.cc
+++ b/src/ScalarToTecplot.cc
@@ -1,7 +1,7 @@
 
 #include "ScalarToTecplot.h"
 #include <stdio.h>
-#include <string>
+#include <cstring>
 #include <vector>
 
 using namespace std;

--- a/src/ScalarToTecplot.h
+++ b/src/ScalarToTecplot.h
@@ -3,7 +3,6 @@
 
 #include "Scalar.h"
 #include <string>
-#include <string.h>
 #include <vector>
 using std::string;
 

--- a/src/ScalarToTecplot.h
+++ b/src/ScalarToTecplot.h
@@ -3,6 +3,7 @@
 
 #include "Scalar.h"
 #include <string>
+#include <string.h>
 #include <vector>
 using std::string;
 

--- a/src/StateVector.cc
+++ b/src/StateVector.cc
@@ -1,0 +1,64 @@
+// StateVector.cc
+//
+// Description:
+// Implementation of the StateVector class
+//
+// Author(s):
+// Daniel Floryan
+//
+// Date: 16 Jan 2019
+//
+// $Revision$
+// $LastChangedDate$
+// $LastChangedBy$
+// $HeadURL$
+
+#include "StateVector.h"
+#include <string>
+#include <stdio.h>
+
+using namespace ibpm;
+
+namespace ibpm {
+
+StateVector::StateVector() {}
+
+StateVector::StateVector(const StateVector& v) {
+    resize( v.x.omega.getGrid(), v.x.f.getNumPoints() );
+    x.q = v.x.q;
+    x.omega = v.x.omega;
+    x.f = v.x.f;
+}
+
+StateVector::StateVector(const State& y) {
+    resize( y.omega.getGrid(), y.f.getNumPoints() );
+    x.q = y.q;
+    x.omega = y.omega;
+    x.f = y.f;
+}
+
+StateVector::StateVector(const Grid& grid, int numPoints ) {
+    resize( grid, numPoints );
+}
+
+void StateVector::resize( const Grid& grid, int numPoints ) {
+    x.q.resize( grid );
+    x.omega.resize( grid );
+    x.f.resize( numPoints );
+}
+
+StateVector::StateVector( string filename ) {
+    load( filename );
+}
+
+StateVector::~StateVector() {}
+
+bool StateVector::load(const std::string& filename) {
+    return x.load(filename);
+}
+
+bool StateVector::save(std::string filename) const {
+    return x.save(filename);
+}
+
+} // namespace ibpm

--- a/src/StateVector.h
+++ b/src/StateVector.h
@@ -1,0 +1,224 @@
+#ifndef _STATEVECTOR_H_
+#define _STATEVECTOR_H_
+
+#include "State.h"
+#include "Grid.h"
+
+namespace ibpm {
+
+/*!
+    \file StateVector.h
+    \class StateVector
+
+    \brief Structure for grouping state variables as a vector
+
+    \author Daniel Floryan
+    \author $LastChangedBy$
+    \date  16 Jan 2019
+    \date $LastChangedDate$
+    \version $Revision$
+*/
+
+class StateVector {
+public:
+    /// Default constructor: do not allocate memory
+    StateVector();
+
+    StateVector( const StateVector& v);
+
+    StateVector( const State& y);
+    	  		
+    StateVector( const Grid& grid, int numPoints );
+
+    /// \brief Instantiate a state by reading data from the specified file
+    StateVector( string filename );
+
+    ~StateVector();
+    
+    /// \brief Allocate memory, with the specified Grid and number of
+    /// boundary points
+    void resize( const Grid& grid, int numPoints );
+
+    /// \brief Save the State to a file (e.g. as a restart file)
+    /// Return true if successful
+    /*  WARNING:  At this point, the xshift and yshift parameters are not saved
+     and are not checked for compatibility when loading.  Caution should be
+     taken when working with shifted grids.  This approach was taken to pre-
+     serve backwards compatibility with previously saved binary files.  In 
+     the future perhaps using HDF5 would prevent such problems.
+     */
+    bool save(std::string filename) const;
+
+    /// \brief Load the state from a file (e.g. as a restart file)
+    /// Return true if successful
+    bool load(const std::string& filename);
+
+    /// Copy assignment
+    inline StateVector& operator=(const StateVector& v) {
+        x.q = v.x.q;
+        x.omega = v.x.omega;
+        x.f = v.x.f;
+        return *this;
+    }
+
+    /// Copy assignment from double
+    inline StateVector& operator=(double a) {
+        x.q = a;
+        x.omega = a;
+        x.f = a;
+        return *this;
+    }
+
+    /// u += v
+    inline StateVector& operator+=(const StateVector& v) {
+        x.q += v.x.q;
+        x.omega += v.x.omega;
+        x.f += v.x.f;
+        return *this;
+    }
+
+    /// u += a
+    inline StateVector& operator+=(double a) {
+        x.q += a;
+        x.omega += a;
+        x.f += a;
+        return *this;
+    }
+
+    /// u -= v
+    inline StateVector& operator-=(const StateVector& v) {
+        x.q -= v.x.q;
+        x.omega -= v.x.omega;
+        x.f -= v.x.f;
+        return *this;
+    }
+
+    /// u -= a
+    inline StateVector& operator-=(double a) {
+        x.q -= a;
+        x.omega -= a;
+        x.f -= a;
+        return *this;
+    }
+
+    /// u *= a
+    inline StateVector& operator*=(double a) {
+        x.q *= a;
+        x.omega *= a;
+        x.f *= a;
+        return *this;
+    }
+
+    /// u /= a
+    inline StateVector& operator/=(double a) {
+        x.q /= a;
+        x.omega /= a;
+        x.f /= a;
+        return *this;
+    }
+
+    /// u + v
+    inline StateVector operator+(const StateVector& v) {
+        StateVector w = *this;
+        w += v;
+        return w;
+    }
+
+    /// u + a
+    inline StateVector operator+(double a) {
+        StateVector w = *this;
+        w += a;
+        return w;
+    }
+    
+    /// u - v
+    inline StateVector operator-(const StateVector& v) {
+        StateVector w = *this;
+        w -= v;
+        return w;
+    }
+
+    /// u - a
+    inline StateVector operator-(double a) {
+        StateVector w = *this;
+        w -= a;
+        return w;
+    }
+    
+    /// u * a
+    inline StateVector operator*(double a) {
+        StateVector w = *this;
+        w *= a;
+        return w;
+    }
+    
+    /// u / a
+    inline StateVector operator/(double a) {
+        StateVector w = *this;
+        w /= a;
+        return w;
+    }
+			    
+    // public data
+    State x;
+};  // class StateVector
+
+/// -v
+inline StateVector operator-(const StateVector& v) {
+    StateVector w = v;
+    w *= -1;
+    return w;
+}
+
+/// u + v
+inline StateVector operator+(const StateVector& u, const StateVector& v) {
+    StateVector w = u;
+    w += v;
+    return w;
+};
+
+/// a + v
+inline StateVector operator+(double a, const StateVector& v) {
+    StateVector w = v;
+    w += a;
+    return w;
+};
+
+/// u - v
+inline StateVector operator-(const StateVector& u, const StateVector& v) {
+    StateVector w = u;
+    w -= v;
+    return w;
+};
+    
+/// a - v
+inline StateVector operator-(double a, const StateVector& v) {
+    StateVector w = -v;
+    w += a;
+    return w;
+};
+
+/// a * v
+inline StateVector operator*(double a, const StateVector& v) {
+    StateVector w = v;
+    w *= a;
+    return w;
+}
+
+/// v * a
+inline StateVector operator*(const StateVector& v, double a) {
+    StateVector w = v;
+    w *= a;
+    return w;
+}
+
+/// v / a
+inline StateVector operator/(const StateVector& v, double a) {
+    StateVector w = v;
+    w /= a;
+    return w;
+}
+
+} // namespace ibpm
+
+#endif /* _STATEVECTOR_H_ */

--- a/src/ibpm.h
+++ b/src/ibpm.h
@@ -26,6 +26,7 @@
 #include "BoundaryVector.h"
 #include "BaseFlow.h"
 #include "State.h"
+#include "StateVector.h"
 
 // operations
 #include "VectorOperations.h"


### PR DESCRIPTION
The StateVector class is like the State class, but allows for addition
and scalar multiplication of StateVector objects, hence the name. This
functionality is useful for numerical root-finding of a flow map, for
example.

State objects contain timestep and time member variables. It is unclear
how to best handle these variables when adding States or multiplying
them by a scalar. We have made the arbitrary choice of setting these
variables equal to zero for all StateVector objects; addition and
scalar multiplication do not change this.