### PR TITLE
Fix g++ Compilation

### DIFF
--- a/config/make.inc.gcc
+++ b/config/make.inc.gcc
@@ -3,7 +3,7 @@
 CXX = g++
 
 # flags for compiling with optimization
-CXXFLAGS = -Wall -g -fast -funroll-loops -DNDEBUG
+CXXFLAGS = -Wall -g -Ofast -funroll-loops -DNDEBUG
 
 # for debugging, uncomment the following line
 # CXXFLAGS = -Wall -g

--- a/src/ScalarToTecplot.cc
+++ b/src/ScalarToTecplot.cc
@@ -1,7 +1,7 @@
 
 #include "ScalarToTecplot.h"
 #include <stdio.h>
-#include <string>
+#include <cstring>
 #include <vector>
 
 using namespace std;


### PR DESCRIPTION
This fixes some small compilation issues on gnu compilers
* `g++` doesn't seem to have a `-fast` flag.
* `strncpy` requires `cstring`.