### PR TITLE
Remove usage of 'using namespace std' and add motion

### DIFF
--- a/examples/Oseen.cc
+++ b/examples/Oseen.cc
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
 	// Setup grid
 	int nx = 100;
 	int ny = 100;
-    int ngrid = 3;
+    int ngrid = 1;
 	double length = 10;
     double xOffset = -5;
     double yOffset = -5;

--- a/src/BaseFlow.cc
+++ b/src/BaseFlow.cc
@@ -30,7 +30,6 @@
 #include "utils.h"
 
 
-using namespace std;
 using namespace ibpm;
 
 namespace ibpm {

--- a/src/BaseFlow.h
+++ b/src/BaseFlow.h
@@ -7,7 +7,7 @@
 #include "BoundaryVector.h"
 #include <string>
 
-using namespace std;
+using std::string;
 
 namespace ibpm {
 

--- a/src/CholeskySolver.cc
+++ b/src/CholeskySolver.cc
@@ -20,7 +20,9 @@
 #include <fstream>
 #include <iomanip>
 
-using namespace std;
+using std::ifstream;
+using std::ofstream;
+using std::setprecision;
 
 namespace ibpm {
 

--- a/src/Flux.cc
+++ b/src/Flux.cc
@@ -17,6 +17,8 @@
 #include "Scalar.h"
 #include "Grid.h"
 
+using std::cout;
+
 namespace ibpm {
 
 Flux::Flux() {}

--- a/src/Flux.h
+++ b/src/Flux.h
@@ -8,7 +8,6 @@
 #include "TangentSE2.h"
 #include <math.h>
 #include <iostream>
-using namespace std;
 
 namespace ibpm {
 

--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -22,7 +22,9 @@
 #include <string>
 #include "utils.h"
 
-using namespace std;
+using std::istringstream;
+using std::getline;
+using std::ifstream;
 
 namespace ibpm {
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -6,7 +6,9 @@
 #include "RigidBody.h"
 #include <iostream>
 #include <vector>
-using namespace std;
+
+using std::string;
+using std::vector;
 
 namespace ibpm {
 

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -5,7 +5,7 @@
 #include <math.h>
 //JON
 #include <iostream>
-using namespace std;
+
 namespace ibpm {
 
 /*!

--- a/src/IBSolver.cc
+++ b/src/IBSolver.cc
@@ -11,8 +11,6 @@
 #include "VectorOperations.h"
 #include <string>
 
-using namespace std;
-
 namespace ibpm {
 
 IBSolver::IBSolver( 

--- a/src/IBSolver.h
+++ b/src/IBSolver.h
@@ -11,8 +11,6 @@
 #include "Grid.h"
 #include "NavierStokesModel.h"
 
-using namespace std;
-
 namespace ibpm{
 	
 class ProjectionSolver;

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -20,7 +20,6 @@
 #include "State.h"
 #include "Logger.h"
 
-using namespace std;
 
 namespace ibpm {
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -4,7 +4,8 @@
 #include "BaseFlow.h"
 #include "State.h"
 #include <vector>
-using namespace std;
+
+using std::vector;
 
 namespace ibpm {
 

--- a/src/MotionFile.h
+++ b/src/MotionFile.h
@@ -12,6 +12,8 @@
 #include <vector>
 #include "utils.h"
 
+using std::ifstream;
+
 
 namespace ibpm {
 

--- a/src/MotionFilePeriodic.h
+++ b/src/MotionFilePeriodic.h
@@ -1,0 +1,134 @@
+#ifndef _MOTIONFILEPERIODIC_H_
+#define _MOTIONFILEPERIODIC_H_
+
+#include "Motion.h"
+#include "TangentSE2.h"
+#include <math.h>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+#include "utils.h"
+
+using std::ifstream;
+
+namespace ibpm {
+    
+    // Defining a struct for storing (t,x,y,theta), which I call TTSE2
+    struct TTSE2 {
+        TTSE2(double t_in, double x_in, double y_in, double theta_in, double dx_in, double dy_in, double dtheta_in) {
+            t = t_in;
+            x = x_in;
+            y = y_in;
+            theta = theta_in;
+            dx = dx_in;
+            dy = dy_in;
+            dtheta = dtheta_in;
+        }
+        double t;
+        double x;
+        double y;
+        double theta;
+        double dx;
+        double dy;
+        double dtheta;
+    };
+    
+    /*!
+     \file MotionFilePeriodic.h
+     \class MotionFilePeriodic
+     
+     \brief Subclass of Motion, for periodic motions defined in a file
+     
+     \author Daniel Floryan
+     \author $LastChangedBy: dfloryan $
+     \date 13 Nov 2019
+     \date $LastChangedDate: 2019-11-13 02:41:03 -0400 (Wed, 03 Sep 2008) $
+     \version $Revision: 132 $
+     */
+    
+    class MotionFilePeriodic : public Motion {
+    public:
+        
+        /// \brief Define a Motion corresponding to periodic data specified in a file
+        MotionFilePeriodic(
+                   string filename,
+                   double period
+                   ) :
+        _filename(filename),
+        _period(period) {
+            ifstream in( filename.c_str() );
+            int n;
+            double t,x,y,theta,dx,dy,dtheta;
+            double tlast = -1.e+5;
+            in >> n;
+            if( in.fail() ) {
+                cerr << "ERROR:: MotionFilePeriodic: file " << filename <<" formatted incorrectly! (err1)" << endl;
+            }
+            for(int i=0; i<n; i++) {
+                in >> t >> x >> y >> theta >> dx >> dy >> dtheta;
+                if( in.fail() ) {
+                    cerr << "ERROR:: MotionFilePeriodic: file " << filename << " formatted incorrectly! (err2)" << endl;
+                }
+                if( t<tlast ) {
+                    cerr << "ERROR:: MotionFilePeriodic: time must increase monotonically!" << endl;
+                }
+                tlast = t;
+                addTTSE2(t,x,y,theta,dx,dy,dtheta);
+            }
+        }
+        
+        /// Adds an element of TTSE2 to the vector
+        void addTTSE2(double t, double x, double y, double theta, double dx, double dy, double dtheta) {
+            TTSE2 p(t,x,y,theta,dx,dy,dtheta);
+            // Add the element to the motion file data list
+            _data.push_back(p);
+        }
+        
+        /// Returns transformation for the piecewise linear data in _filename:
+        inline TangentSE2 getTransformation(double time) const {
+            int index = -1;
+            time = fmod(time,_period);
+            // find correct index corresponding to current time
+            int n=_data.size();
+            for(int i=0; i<n-1; i++) {
+                if( (time>=_data[i].t) && (time<_data[i+1].t) ) index = i;
+            }
+            double xo = 0.;
+            double yo = 0.;
+            double thetao = 0.;
+            double dxo = 0.;
+            double dyo = 0.;
+            double dthetao = 0.;
+            double alpha=0.;
+            double tdiff=0.;
+            if( index != -1 ) {
+                tdiff = _data[index+1].t-_data[index].t;
+                alpha = (time-_data[index].t)/tdiff;
+                xo = alpha*_data[index+1].x+(1-alpha)*_data[index].x;
+                yo = alpha*_data[index+1].y+(1-alpha)*_data[index].y;
+                thetao = alpha*_data[index+1].theta+(1-alpha)*_data[index].theta;
+                dxo = alpha*_data[index+1].dx+(1-alpha)*_data[index].dx;
+                dyo = alpha*_data[index+1].dy+(1-alpha)*_data[index].dy;
+                dthetao = alpha*_data[index+1].dtheta+(1-alpha)*_data[index].dtheta;
+            }
+            return TangentSE2( xo, yo, thetao, dxo, dyo, dthetao );
+        }
+        
+        inline Motion* clone() const {
+            return new MotionFilePeriodic(
+                                  _filename,
+                                  _period
+                                  );
+        };
+        
+    private:
+        string _filename;
+        double _period;
+        vector<TTSE2> _data;
+    };
+} // namespace ibpm
+
+#endif /* _MOTIONFILEPERIODIC_H_ */

--- a/src/OutputEnergy.cc
+++ b/src/OutputEnergy.cc
@@ -4,7 +4,6 @@
 #include "VectorOperations.h"
 #include <stdio.h>
 #include <string>
-using namespace std;
 
 namespace ibpm {
 

--- a/src/OutputForce.cc
+++ b/src/OutputForce.cc
@@ -21,7 +21,6 @@
 #include "VectorOperations.h"
 #include <stdio.h>
 #include <string>
-using namespace std;
 
 namespace ibpm {
 

--- a/src/OutputProbes.cc
+++ b/src/OutputProbes.cc
@@ -17,7 +17,6 @@
 #include <vector>
 #include <stdio.h>
 #include <string>
-using namespace std;
 
 namespace ibpm {
 

--- a/src/OutputProbes.h
+++ b/src/OutputProbes.h
@@ -6,7 +6,9 @@
 #include "Array.h"
 #include <vector>
 #include <string>
-using namespace std;
+
+using std::string;
+using std::vector;
 
 namespace ibpm {
 

--- a/src/OutputRestart.cc
+++ b/src/OutputRestart.cc
@@ -18,7 +18,6 @@
 #include "Output.h"
 #include <stdio.h>
 #include <string>
-using namespace std;
 
 namespace ibpm {
 

--- a/src/OutputTecplot.cc
+++ b/src/OutputTecplot.cc
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 namespace ibpm {
 
 OutputTecplot::OutputTecplot( string filename, string title, bool TecplotAllGrids ) {

--- a/src/ParmParser.cc
+++ b/src/ParmParser.cc
@@ -17,8 +17,6 @@
 #include <fstream>
 #include <iomanip>
 
-using namespace std;
-
 const int OPTION_WIDTH = 20;
 
 ParmParser::ParmParser(int argc, char* argv[]) :

--- a/src/ParmParser.h
+++ b/src/ParmParser.h
@@ -5,7 +5,18 @@
 #include <sstream>
 #include <iostream>
 #include <vector>
-using namespace std;
+#include <iomanip>
+
+using std::string;
+using std::ostream;
+using std::vector;
+using std::ostringstream;
+using std::endl;
+using std::ios_base;
+using std::setw;
+using std::istringstream;
+using std::cerr;
+using std::fstream;
 
 /*!
     \file ParmParser.h

--- a/src/RandomNumber.h
+++ b/src/RandomNumber.h
@@ -5,8 +5,6 @@ typedef unsigned long long int Ullong;
 typedef unsigned int Uint;
 typedef double Doub;
 
-using namespace std;
-
 class RandomNumber {
 public:
     // Constructor. Call with any integer seed (except value of v above).

--- a/src/Regularizer.cc
+++ b/src/Regularizer.cc
@@ -20,8 +20,6 @@
 #include <vector>
 #include <math.h>
 
-using namespace std;
-
 namespace ibpm {
 
 Regularizer::Regularizer(const Grid& grid, const Geometry& geometry) :

--- a/src/Regularizer.h
+++ b/src/Regularizer.h
@@ -5,6 +5,8 @@
 #include "Flux.h"
 #include "BoundaryVector.h"
 
+using std::vector;
+
 namespace ibpm {
 
 class Grid;

--- a/src/RigidBody.cc
+++ b/src/RigidBody.cc
@@ -37,6 +37,7 @@
 #include "Eldredge1.h"
 #include "Eldredge2.h"
 #include "MotionFile.h"
+#include "MotionFilePeriodic.h"
 #include <string>
 #include <fstream>
 #include <iostream>
@@ -44,7 +45,9 @@
 #include <sstream>
 #include "utils.h"
 
-using namespace std;
+using std::setw;
+using std::ifstream;
+using std::istringstream;
 
 namespace ibpm {
 
@@ -476,6 +479,15 @@ bool RigidBody::load(istream& in) {
                 one_line >> filename;
                 RB_CHECK_FOR_ERRORS;
                 Motion* m = new MotionFile( filename );
+                setMotion( *m );
+            }
+            else if ( motionType == "motionfileperiodic" ) {
+                // Periodic motion defined in a file
+                string filename;
+                double period;
+                one_line >> filename >> period;
+                RB_CHECK_FOR_ERRORS;
+                Motion* m = new MotionFilePeriodic( filename, period );
                 setMotion( *m );
             }
         }

--- a/src/RigidBody.h
+++ b/src/RigidBody.h
@@ -6,7 +6,10 @@
 #include <vector>
 #include <math.h>
 
-using namespace std;
+using std::string;
+using std::vector;
+using std::istream;
+using std::ostream;
 
 namespace ibpm {
 

--- a/src/Scalar.cc
+++ b/src/Scalar.cc
@@ -15,7 +15,8 @@
 
 #include "Scalar.h"
 #include <iostream>
-using namespace std;
+
+using std::cout;
 
 namespace ibpm {
 

--- a/src/Scalar.h
+++ b/src/Scalar.h
@@ -5,8 +5,7 @@
 #include "BC.h"
 #include "Field.h"
 #include "Grid.h"
-#include <iostream>
-using namespace std;  
+#include <iostream>  
  
 namespace ibpm {
 

--- a/src/ScalarToTecplot.cc
+++ b/src/ScalarToTecplot.cc
@@ -4,8 +4,6 @@
 #include <cstring>
 #include <vector>
 
-using namespace std;
-
 namespace ibpm {
     
 class VarList {

--- a/src/ScalarToTecplot.h
+++ b/src/ScalarToTecplot.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 using std::string;
+using std::vector;
 
 namespace ibpm {
 

--- a/src/Scheme.h
+++ b/src/Scheme.h
@@ -3,7 +3,8 @@
 #include "Array.h"
 #include <string>
 
-using namespace std;
+using std::string;
+using std::cout;
 
 class Scheme {
 public:

--- a/src/State.h
+++ b/src/State.h
@@ -7,6 +7,8 @@
 #include "BoundaryVector.h"
 #include <string>
 
+using std::string;
+
 namespace ibpm {
 
 /*!

--- a/src/StateVector.cc
+++ b/src/StateVector.cc
@@ -28,6 +28,8 @@ StateVector::StateVector(const StateVector& v) {
     x.q = v.x.q;
     x.omega = v.x.omega;
     x.f = v.x.f;
+    x.timestep = v.x.timestep;
+    x.time = v.x.time;
 }
 
 StateVector::StateVector(const State& y) {
@@ -35,6 +37,8 @@ StateVector::StateVector(const State& y) {
     x.q = y.q;
     x.omega = y.omega;
     x.f = y.f;
+    x.timestep = y.timestep;
+    x.time = y.time;
 }
 
 StateVector::StateVector(const Grid& grid, int numPoints ) {

--- a/src/StateVector.h
+++ b/src/StateVector.h
@@ -58,6 +58,8 @@ public:
         x.q = v.x.q;
         x.omega = v.x.omega;
         x.f = v.x.f;
+        x.timestep = v.x.timestep;
+        x.time = v.x.time;
         return *this;
     }
 
@@ -66,6 +68,8 @@ public:
         x.q = a;
         x.omega = a;
         x.f = a;
+        x.timestep = 0;
+        x.time = 0;
         return *this;
     }
 

--- a/src/VectorOperations.cc
+++ b/src/VectorOperations.cc
@@ -24,7 +24,7 @@
 #include "NavierStokesModel.h"
 #include <fftw3.h>
 #include <iostream>
-using namespace std;
+
 using Array::Array2;
 
 namespace ibpm {

--- a/src/checkgeom.cc
+++ b/src/checkgeom.cc
@@ -20,7 +20,6 @@
 #include "ibpm.h"
 #include "Regularizer.h"
 
-using namespace std;
 using namespace ibpm;
 
 int main(int argc, char* argv[]) {

--- a/src/ibpm.cc
+++ b/src/ibpm.cc
@@ -19,7 +19,6 @@ $HeadURL$
 #include <sys/stat.h>
 #include "ibpm.h"
 
-using namespace std;
 using namespace ibpm;
 
 enum ModelType { LINEAR, NONLINEAR, ADJOINT, LINEARPERIODIC, SFD, INVALID };

--- a/src/ibpm.h
+++ b/src/ibpm.h
@@ -48,6 +48,7 @@
 #include "Eldredge1.h"
 #include "Eldredge2.h"
 #include "MotionFile.h"
+#include "MotionFilePeriodic.h"
 
 // output routines
 #include "Logger.h"

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -16,7 +16,7 @@
 #include <string>
 #include <ctype.h>
 
-using namespace std;
+using std::string;
 
 void EatWhitespace( string& s ) {
     while ( isspace( s[0] ) ) {


### PR DESCRIPTION
Usage of 'using namespace std' is considered bad practice, so I have
removed all instances of it.
Added a new motion type that reads in periodic motions from a file.
Updated how class StateVector handles time.
The Oseen example in the example directory does not work when ngrid>1,
so I set ngrid=1. This issue is not critical but should be explored.
Perhaps this problem arises because the Oseen example does not have a
body.